### PR TITLE
test-vk: fix segfault when zxdg_decoration_manager_v1 is not supported

### DIFF
--- a/demo/test-vk.c
+++ b/demo/test-vk.c
@@ -106,7 +106,7 @@ static struct xdg_wm_base *shell = NULL;
 static struct xdg_surface *shellSurface = NULL;
 static struct xdg_toplevel *toplevel = NULL;
 static struct zxdg_decoration_manager_v1 *decoration_manager = NULL;
-static struct zxdg_toplevel_decoration_v1 *decoration;
+static struct zxdg_toplevel_decoration_v1 *decoration = NULL;
 static int quit = 0;
 static int readyToResize = 0;
 static int resize = 0;
@@ -630,14 +630,19 @@ int main(int argc, char **argv) {
     CHECK_WL_RESULT(toplevel = xdg_surface_get_toplevel(shellSurface));
     xdg_toplevel_add_listener(toplevel, &toplevelListener, NULL);
 
-    CHECK_WL_RESULT(decoration =
-                        zxdg_decoration_manager_v1_get_toplevel_decoration(
-                            decoration_manager, toplevel));
+    if (decoration_manager) {
+        CHECK_WL_RESULT(decoration =
+                            zxdg_decoration_manager_v1_get_toplevel_decoration(
+                                decoration_manager, toplevel));
+    }
 
     xdg_toplevel_set_title(toplevel, appName);
     xdg_toplevel_set_app_id(toplevel, appName);
-    zxdg_toplevel_decoration_v1_set_mode(
-        decoration, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+
+    if (decoration) {
+        zxdg_toplevel_decoration_v1_set_mode(
+            decoration, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+    }
 
     wl_surface_commit(surface);
     wl_display_roundtrip(display);


### PR DESCRIPTION
The code in `demo/test-vk.c` assumes that the `zxdg_decoration_manager_v1` wayland protocol is always supported, resulting in a segfault when it is not.

For example this happens when running on Gnome desktop, where `decoration_manager` is never initialized by `handleRegistry()`.

Check if `decoration_manager` has been initialized before using it, to make the demo work also in case zxdg_decoration_manager_v1 is not supported, even if that means leaving the window without decorations.

The "_proper_" fix for Gnome would probably be to use `libdecor`, but I don't have time to spend on that.