### PR TITLE
Pipewire Node Name

### DIFF
--- a/src/funnel.c
+++ b/src/funnel.c
@@ -1251,6 +1251,10 @@ int funnel_stream_configure(struct funnel_stream *stream) {
         // clang-format on
         assert(props);
 
+        const char *node_name = getenv("LIBFUNNEL_NODE_NAME") ?: stream->name;                
+        if (*node_name)
+            pw_properties_set(props, PW_KEY_NODE_NAME, node_name);
+
         stream->stream = pw_stream_new(ctx->core, stream->name, props);
         if (!stream->stream) {
             pw_log_error("failed to create PW stream");

--- a/src/funnel.c
+++ b/src/funnel.c
@@ -1253,7 +1253,7 @@ int funnel_stream_configure(struct funnel_stream *stream) {
 
         const char *node_name = getenv("LIBFUNNEL_NODE_NAME") ?: stream->name;                
         if (*node_name)
-            pw_properties_set(props, PW_KEY_NODE_NAME, node_name);
+            pw_properties_set(props, PW_KEY_NODE_NICK, node_name);
 
         stream->stream = pw_stream_new(ctx->core, stream->name, props);
         if (!stream->stream) {


### PR DESCRIPTION
Set `PW_KEY_NODE_NAME` so that `node.name` matches `media.name` by default. Prevents PipeWire from falling back to the process binary name (i.e. `wine64-preloader`)

Optionally added `LIBFUNNEL_NODE_NAME` environment variable, If set to a non-empty value, it is used as `node.name`.

If set to an empty string (`LIBFUNNEL_NODE_NAME=""`), `PW_KEY_NODE_NAME` is not set, restoring the previous behavior where PipeWire falls back to the binary name.

Closes: https://github.com/hoshinolina/spout2pw/issues/25
